### PR TITLE
Update caching behavior

### DIFF
--- a/template/.github/workflows/ci-python.yml.jinja
+++ b/template/.github/workflows/ci-python.yml.jinja
@@ -76,8 +76,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions>=2.0
 
-    - name: tox cache
-      uses: actions/cache@v4
+    - name: Load tox cache
+      uses: actions/cache/restore@v4
       with:
         path: .tox/
         key: {% raw %}${{ runner.os }}-${{ matrix.python-version }}-tox-v1-${{ hashFiles('**/pyproject.toml') }}{% endraw %}
@@ -88,3 +88,10 @@ jobs:
       run: tox -e {% raw %}${{{% endraw %} matrix.python-version == '{{ requires_python }}' && 'msv' || 'latest' {% raw %}}}{% endraw %}
       env:
         PYTHONDEVMODE: 1
+
+    - name: Save tox cache (only on main)
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v4
+      with:
+        path: .tox/
+        key: {% raw %}${{ runner.os }}-${{ matrix.python-version }}-tox-v1-${{ hashFiles('**/pyproject.toml') }}{% endraw %}


### PR DESCRIPTION
Update GHA to only restore cache on a PR branch, and then only save it if running from main. This reduces cache rotation, just like we do for the rust action