### PR TITLE
More consistent use of `project_name`

### DIFF
--- a/template/INSTALL.md.jinja
+++ b/template/INSTALL.md.jinja
@@ -20,7 +20,7 @@ Download from {{ repository }}/releases
 
 ### Installing with Pixi (recommended)
 
-We recommend using `pixi` to manage a Python environment with `{{ project_slug }}` and all the required dependencies since it can reproduce exactly what we use for development.
+We recommend using `pixi` to manage a Python environment with `{{ project_name }}` and all the required dependencies since it can reproduce exactly what we use for development.
 
 1. Install `pixi` itself on your system. You only need to do this once, so you can skip this step if you already have `pixi` installed.
 

--- a/template/INSTALL.md.jinja
+++ b/template/INSTALL.md.jinja
@@ -20,7 +20,7 @@ Download from {{ repository }}/releases
 
 ### Installing with Pixi (recommended)
 
-We recommend using `pixi` to manage a Python environment with `{{ project_name }}` and all the required dependencies since it can reproduce exactly what we use for development.
+We recommend using `pixi` to manage a Python environment with `{{ project_slug }}` and all the required dependencies since it can reproduce exactly what we use for development.
 
 1. Install `pixi` itself on your system. You only need to do this once, so you can skip this step if you already have `pixi` installed.
 
@@ -36,7 +36,7 @@ For Windows:
    powershell -ExecutionPolicy ByPass -c "irm -useb https://pixi.sh/install.ps1 | iex"
    ```
 
-2. Clone {{project_name}} repository if you don't already have it.
+2. Clone the {{project_name}} repository if you don't already have it.
 
 3. Pixi provides support to use virtual environment with all the dependencies
    required. To do so, pixi uses the information from `pyproject.toml` and

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -6,7 +6,7 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [project]
-name="{{ project_slug }}"
+name="{{ project_name }}"
 dynamic = ["version"]
 description = "{{ package_short_description }}"
 readme = "README.md"


### PR DESCRIPTION
Base don #16, I thought I would have to clean up some of the issue template/GHA Jinja templates, but most look good. Found a few minor instances where i thought it made sense to change. LMK if you agree or not.

Also, do we want to have the project use an `NREL-{{project_name}}` prefix? I think this has been a convention in our group, but IDK if we want to have it as a suggestion or leave it to the users to add it if they want it