### PR TITLE
fix: Including template's README

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -1,6 +1,5 @@
 # questions
 _exclude:
-    - README.md
 _subdirectory: template
 project_title:
     type: str


### PR DESCRIPTION
Originally, the template was directly in the root, so we had to exclude the repository template, but now that we moved the template to its own directory, we can have the repository readme and the template readme.