### PR TITLE
Defining `fallback_version` for setuptools_scm

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -158,6 +158,9 @@ max-positional-args = 10
 packages = ["{{ project_slug }}"]
 
 [tool.setuptools_scm]
+fallback_version = "9999"
+# This spec below forces setuptools_scm to look strictly for vX.X.X tags
+git_describe_command = [ "git", "describe", "--dirty", "--tags", "--long", "--match", "v*[0-9]*" ]
 version_file = "{{ project_slug }}/_version.py"
 
 [tool.pixi.project]


### PR DESCRIPTION
Particularly useful when missing any valid tags history, such as a brand new branch or a shallow checkout. The default is to use `0.1.0`, which is not a bad choice, but showing version `10000` makes it clear what is the issue.