### PR TITLE
typo: Remove the `@` from the example

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -42,7 +42,7 @@ repository:
     help: What is the repository URL?
 github_username:
     type: str
-    placeholder: "@castelao"
+    placeholder: "castelao"
     help: What is your GitHub username?
 requires_python:
     type: str

--- a/template/.github/CODEOWNERS.jinja
+++ b/template/.github/CODEOWNERS.jinja
@@ -1,2 +1,2 @@
 # Default owners for everything in this repository.
-*    {{ github_username }}
+*    @{{ github_username }}


### PR DESCRIPTION
By showing '@castelao' we induce the user to add the `@` while we actually just want the username part.