### PR TITLE
Trim empty lines when conditional is false

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -1,4 +1,4 @@
-# Copier setttings
+# Copier settings
 _envops:
   trim_blocks: true
   lstrip_blocks: true

--- a/copier.yml
+++ b/copier.yml
@@ -1,5 +1,10 @@
-# questions
+# Copier setttings
+_envops:
+  trim_blocks: true
+  lstrip_blocks: true
 _subdirectory: template
+
+# Questions
 project_title:
     type: str
     placeholder: "NLR's Modern Data Standards"


### PR DESCRIPTION
Some full lines on the templates are conditional, and before this, if conditional was false would lead to empty lines.